### PR TITLE
Remove non-determinism from Lock Contract

### DIFF
--- a/gallery-workflows/src/test/kotlin/com/r3/gallery/workflows/InitAndClearTests.kt
+++ b/gallery-workflows/src/test/kotlin/com/r3/gallery/workflows/InitAndClearTests.kt
@@ -6,6 +6,7 @@ import com.r3.gallery.states.ArtworkState
 import com.r3.gallery.workflows.artwork.IssueArtworkFlow
 import com.r3.gallery.workflows.internal.issueArtwork
 import com.r3.gallery.workflows.internal.mockNetwork
+import com.r3.gallery.workflows.internal.moveClock
 import com.r3.gallery.workflows.token.BurnTokens
 import com.r3.gallery.workflows.token.GetBalanceFlow
 import com.r3.gallery.workflows.token.IssueTokensFlow
@@ -92,6 +93,9 @@ class InitAndClearTests {
         assert(balance == 990.GBP)
         assert(sellerBalance == 1000.GBP)
 
+        // ensure clock is shifted before reverting encumbered tokens
+        moveClock(setOf(gallery, seller, buyer, bidder, network.defaultNotaryNode), 6000)
+        network.waitQuiescent()
         // BURN tokens from both perspectives
         buyer.startFlow(BurnTokens("GBP")).getOrThrow()
         seller.startFlow(BurnTokens("GBP")).getOrThrow()

--- a/gallery-workflows/src/test/kotlin/com/r3/gallery/workflows/RevertEncumberedTokenFlowTests.kt
+++ b/gallery-workflows/src/test/kotlin/com/r3/gallery/workflows/RevertEncumberedTokenFlowTests.kt
@@ -7,6 +7,7 @@ import com.r3.gallery.utils.getNotaryTransactionSignature
 import com.r3.gallery.workflows.artwork.IssueArtworkFlow
 import com.r3.gallery.workflows.internal.issueArtwork
 import com.r3.gallery.workflows.internal.mockNetwork
+import com.r3.gallery.workflows.internal.moveClock
 import com.r3.gallery.workflows.internal.queryArtworkState
 import com.r3.gallery.workflows.token.GetBalanceFlow
 import com.r3.gallery.workflows.token.IssueTokensFlow
@@ -99,6 +100,9 @@ class RevertEncumberedTokenFlowTests {
 
         val buyerBalanceAfterOffer = buyer.startFlow(GetBalanceFlow(GBP)).getOrThrow()
 
+        moveClock(setOf(gallery, seller, buyer, bidder, network.defaultNotaryNode), 6000)
+        network.waitQuiescent()
+
         seller.startFlow(RevertEncumberedTokensFlow(signedTokensOfferTx.id)).getOrThrow()
 
         val buyerBalanceAfterRedeem = buyer.startFlow(GetBalanceFlow(GBP)).getOrThrow()
@@ -135,6 +139,9 @@ class RevertEncumberedTokenFlowTests {
 
         val buyerBalanceAfterOffer = buyer.startFlow(GetBalanceFlow(GBP)).getOrThrow()
         val otherBuyerBalanceAfterOffer = otherBuyer.startFlow(GetBalanceFlow(GBP)).getOrThrow()
+
+        moveClock(setOf(gallery, seller, buyer, bidder, otherBuyer, otherBidder, network.defaultNotaryNode), 6000)
+        network.waitQuiescent()
 
         seller.startFlow(RevertEncumberedTokensFlow(signedTokensOfferTx.id)).getOrThrow()
         seller.startFlow(RevertEncumberedTokensFlow(otherSignedTokensOfferTx.id)).getOrThrow()
@@ -189,6 +196,8 @@ class RevertEncumberedTokenFlowTests {
         // claim winning bidder's tokens
         seller.startFlow(UnlockEncumberedTokensFlow(signedTokensOfferTx.id, requiredSignature)).getOrThrow()
 
+        moveClock(setOf(gallery, seller, buyer, bidder, otherBuyer, otherBidder, network.defaultNotaryNode), 6000)
+        network.waitQuiescent()
         // early-revert token to losing bidder
         seller.startFlow(RevertEncumberedTokensFlow(otherSignedTokensOfferTx.id)).getOrThrow()
 

--- a/gallery-workflows/src/test/kotlin/com/r3/gallery/workflows/internal/TestUtilities.kt
+++ b/gallery-workflows/src/test/kotlin/com/r3/gallery/workflows/internal/TestUtilities.kt
@@ -6,11 +6,11 @@ import com.r3.gallery.workflows.artwork.IssueArtworkFlow
 import net.corda.core.node.services.Vault
 import net.corda.core.node.services.vault.QueryCriteria
 import net.corda.core.utilities.getOrThrow
-import net.corda.testing.node.MockNetwork
-import net.corda.testing.node.MockNetworkParameters
-import net.corda.testing.node.StartedMockNode
-import net.corda.testing.node.TestCordapp
+import net.corda.testing.node.*
+import java.sql.Time
+import java.time.Duration
 import java.time.Instant
+import java.time.temporal.TemporalUnit
 
 internal fun StartedMockNode.issueArtwork(): ArtworkState {
     val flow = IssueArtworkFlow(ArtworkId.randomUUID(), Instant.now().plusSeconds(5000L))
@@ -40,4 +40,11 @@ internal fun mockNetwork() : MockNetwork {
     )
 
     return network
+}
+
+internal fun moveClock(startedMockNodes: Set<StartedMockNode>, shiftInSeconds: Long){
+    val now = Instant.now()
+    startedMockNodes.forEach {
+        (it.services.clock as TestClock).setTo(now.plusSeconds(shiftInSeconds))
+    }
 }


### PR DESCRIPTION
The `LockContract` used `Instant.now()` to check the reversal of the encumbered tokens once the time window expired. We change the approach to mandate a `TimeWindow` on the Reversal transaction and ensure that it falls outside the time window originally committed in the `LockState`. This precludes the possibility of non-determinism in the `LockContract`.

Updated unit tests as well to make tests pass.